### PR TITLE
Fix BLEU score calculation - treat predictions and labels as word lists

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -356,6 +356,8 @@ def sentence_calc_bleu_n(pred, label, n):
     return score
 
 def calc_bleu_n(pred, label, n):
+    label = [[lab.split()] for lab in label]
+    pred = [p.split() for p in pred]
     if n == 1:
         score = nltk.translate.bleu_score.corpus_bleu(label, pred, weights=(1, 0, 0, 0))
     elif n == 2:


### PR DESCRIPTION
Previously, predictions and labels were incorrectly treated as strings, leading to BLEU scores being computed over character-level n-grams instead of word-level n-grams. This fix ensures that predictions and labels are passed as lists of words and lists of lists of words, respectively, so that the BLEU score reflects proper word-level comparisons.